### PR TITLE
Fix scrambling of PATH order in Windows shell plug-ins

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -120,7 +120,8 @@ class PowerShellBase(Shell):
             if match:
                 paths.extend(match.group(2).split(os.pathsep))
 
-        cls.syspaths = list(set([x for x in paths if x]))
+        seen = set()
+        cls.syspaths = [x for x in paths if x and x not in seen and not seen.add(x)]
 
         return cls.syspaths
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -132,7 +132,9 @@ class CMD(Shell):
             if match:
                 paths.extend(match.group(2).split(os.pathsep))
 
-        cls.syspaths = set([x for x in paths if x])
+        seen = set()
+        cls.syspaths = [x for x in paths if x and x not in seen and not seen.add(x)]
+
         return cls.syspaths
 
     def _bind_interactive_rez(self):


### PR DESCRIPTION
shell plug-ins. This is copied directly from the
Pixomondo Rez fork here:
https://github.com/Pixomondo/rez/commit/ae10c1580f66ae11d9d11ef1392b2a9b8b33e9ac